### PR TITLE
Return 312 when no-route error occurs

### DIFF
--- a/amqp/extended_constants.go
+++ b/amqp/extended_constants.go
@@ -1,0 +1,5 @@
+package amqp
+
+// NoRoute returns when a 'mandatory' message cannot be delivered to any queue.
+// @see https://www.rabbitmq.com/amqp-0-9-1-errata.html#section_17
+const NoRoute = 312

--- a/server/channel.go
+++ b/server/channel.go
@@ -244,7 +244,7 @@ func (channel *Channel) handleContentBody(bodyFrame *amqp.Frame) *amqp.Error {
 	ex := vhost.GetExchange(message.Exchange)
 	if ex == nil {
 		channel.SendContent(
-			&amqp.BasicReturn{ReplyCode: amqp.NoConsumers, ReplyText: "No route", Exchange: message.Exchange, RoutingKey: message.RoutingKey},
+			&amqp.BasicReturn{ReplyCode: amqp.NoRoute, ReplyText: "No route", Exchange: message.Exchange, RoutingKey: message.RoutingKey},
 			message,
 		)
 		return nil
@@ -255,7 +255,7 @@ func (channel *Channel) handleContentBody(bodyFrame *amqp.Frame) *amqp.Error {
 	if len(matchedQueues) == 0 {
 		if message.Mandatory {
 			channel.SendContent(
-				&amqp.BasicReturn{ReplyCode: amqp.NoConsumers, ReplyText: "No route", Exchange: message.Exchange, RoutingKey: message.RoutingKey},
+				&amqp.BasicReturn{ReplyCode: amqp.NoRoute, ReplyText: "No route", Exchange: message.Exchange, RoutingKey: message.RoutingKey},
 				message,
 			)
 		} else {
@@ -277,7 +277,7 @@ func (channel *Channel) handleContentBody(bodyFrame *amqp.Frame) *amqp.Error {
 		if qu == nil {
 			if message.Mandatory {
 				channel.SendContent(
-					&amqp.BasicReturn{ReplyCode: amqp.NoConsumers, ReplyText: "No route", Exchange: message.Exchange, RoutingKey: message.RoutingKey},
+					&amqp.BasicReturn{ReplyCode: amqp.NoRoute, ReplyText: "No route", Exchange: message.Exchange, RoutingKey: message.RoutingKey},
 					message,
 				)
 			} else {


### PR DESCRIPTION
RabbitMQ returns code `312` when no-route error occurs: https://www.rabbitmq.com/amqp-0-9-1-errata.html#section_17