### PR TITLE
exchange: add basic header support

### DIFF
--- a/binding/binding.go
+++ b/binding/binding.go
@@ -8,6 +8,16 @@ import (
 	"github.com/valinurovam/garagemq/amqp"
 )
 
+// MatchType is the x-match attribute in a binding argument table
+type MatchType int
+
+const (
+	// MatchAll requires all registered arguments to match for routing
+	MatchAll MatchType = iota
+	// MatchAny requires any registered arguments to match for routing
+	MatchAny
+)
+
 // Binding represents AMQP-binding
 type Binding struct {
 	Queue      string

--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -164,6 +164,20 @@ func (ex *Exchange) GetMatchedQueues(message *amqp.Message) (matchedQueues map[s
 				matchedQueues[bind.GetQueue()] = true
 			}
 		}
+	case ExTypeHeaders:
+		if message.Header == nil {
+			return
+		}
+		props := message.Header.PropertyList
+		if props == nil {
+			return
+		}
+		header := props.Headers
+		for _, bind := range ex.bindings {
+			if bind.MatchHeader(message.Exchange, header) {
+				matchedQueues[bind.GetQueue()] = true
+			}
+		}
 	}
 	return
 }

--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -29,7 +29,13 @@ func TestNew(t *testing.T) {
 
 func TestExchange_AppendBinding(t *testing.T) {
 	e := getTestEx()
-	b := binding.NewBinding("test", "test", "test", &amqp.Table{}, false)
+	b, err := binding.NewBinding("test", "test", "test", &amqp.Table{}, false)
+
+	if err != nil {
+		t.Errorf(err.Error())
+		return
+	}
+
 	e.AppendBinding(b)
 	e.AppendBinding(b)
 	l := len(e.GetBindings())
@@ -51,7 +57,13 @@ func TestExchange_AppendBinding(t *testing.T) {
 
 func TestExchange_RemoveBinding(t *testing.T) {
 	e := getTestEx()
-	b := binding.NewBinding("test", "test", "test", &amqp.Table{}, false)
+	b, err := binding.NewBinding("test", "test", "test", &amqp.Table{}, false)
+
+	if err != nil {
+		t.Errorf(err.Error())
+		return
+	}
+
 	e.AppendBinding(b)
 	e.RemoveBinding(b)
 
@@ -69,7 +81,13 @@ func TestExchange_RemoveBinding(t *testing.T) {
 
 func TestExchange_GetBindings(t *testing.T) {
 	e := getTestEx()
-	b := binding.NewBinding("test", "test", "test", &amqp.Table{}, false)
+	b, err := binding.NewBinding("test", "test", "test", &amqp.Table{}, false)
+
+	if err != nil {
+		t.Errorf(err.Error())
+		return
+	}
+
 	e.AppendBinding(b)
 	l := len(e.GetBindings())
 	if l != 1 {
@@ -80,9 +98,30 @@ func TestExchange_GetBindings(t *testing.T) {
 func TestExchange_RemoveQueueBindings(t *testing.T) {
 	e := getTestEx()
 
-	e.AppendBinding(binding.NewBinding("test", "test", "test1", &amqp.Table{}, false))
-	e.AppendBinding(binding.NewBinding("test2", "test", "test2", &amqp.Table{}, false))
-	e.AppendBinding(binding.NewBinding("test", "test", "test3", &amqp.Table{}, false))
+	b1, err := binding.NewBinding("test", "test", "test1", &amqp.Table{}, false)
+
+	if err != nil {
+		t.Errorf(err.Error())
+		return
+	}
+
+	b2, err := binding.NewBinding("test2", "test", "test2", &amqp.Table{}, false)
+
+	if err != nil {
+		t.Errorf(err.Error())
+		return
+	}
+
+	b3, err := binding.NewBinding("test", "test", "test3", &amqp.Table{}, false)
+
+	if err != nil {
+		t.Errorf(err.Error())
+		return
+	}
+
+	e.AppendBinding(b1)
+	e.AppendBinding(b2)
+	e.AppendBinding(b3)
 	e.RemoveQueueBindings("test")
 
 	if len(e.GetBindings()) != 1 {
@@ -110,7 +149,15 @@ func TestExchange_GetMatchedQueues_Direct(t *testing.T) {
 		internal:   false,
 		system:     false,
 	}
-	e.AppendBinding(binding.NewBinding("test_q", "test", "test_rk", &amqp.Table{}, false))
+
+	bind, err := binding.NewBinding("test_q", "test", "test_rk", &amqp.Table{}, false)
+
+	if err != nil {
+		t.Errorf(err.Error())
+		return
+	}
+
+	e.AppendBinding(bind)
 
 	matched := e.GetMatchedQueues(&amqp.Message{
 		Exchange:   "test",
@@ -131,8 +178,23 @@ func TestExchange_GetMatchedQueues_Fanout(t *testing.T) {
 		internal:   false,
 		system:     false,
 	}
-	e.AppendBinding(binding.NewBinding("test_q1", "test", "test_rk", &amqp.Table{}, false))
-	e.AppendBinding(binding.NewBinding("test_q2", "test", "test_rk", &amqp.Table{}, false))
+
+	b1, err := binding.NewBinding("test_q1", "test", "test_rk", &amqp.Table{}, false)
+
+	if err != nil {
+		t.Errorf(err.Error())
+		return
+	}
+
+	b2, err := binding.NewBinding("test_q2", "test", "test_rk", &amqp.Table{}, false)
+
+	if err != nil {
+		t.Errorf(err.Error())
+		return
+	}
+
+	e.AppendBinding(b1)
+	e.AppendBinding(b2)
 
 	matched := e.GetMatchedQueues(&amqp.Message{
 		Exchange: "test",
@@ -155,9 +217,31 @@ func TestExchange_GetMatchedQueues_Topic(t *testing.T) {
 		internal:   false,
 		system:     false,
 	}
-	e.AppendBinding(binding.NewBinding("test_q1", "test", "test_rk.#", &amqp.Table{}, true))
-	e.AppendBinding(binding.NewBinding("test_q2", "test", "test_rk", &amqp.Table{}, true))
-	e.AppendBinding(binding.NewBinding("test_q3", "test", "test", &amqp.Table{}, true))
+
+	b1, err := binding.NewBinding("test_q1", "test", "test_rk.#", &amqp.Table{}, true)
+
+	if err != nil {
+		t.Errorf(err.Error())
+		return
+	}
+
+	b2, err := binding.NewBinding("test_q2", "test", "test_rk", &amqp.Table{}, true)
+
+	if err != nil {
+		t.Errorf(err.Error())
+		return
+	}
+
+	b3, err := binding.NewBinding("test_q3", "test", "test", &amqp.Table{}, true)
+
+	if err != nil {
+		t.Errorf(err.Error())
+		return
+	}
+
+	e.AppendBinding(b1)
+	e.AppendBinding(b2)
+	e.AppendBinding(b3)
 
 	matched := e.GetMatchedQueues(&amqp.Message{
 		Exchange:   "test",

--- a/server/server_exchange_test.go
+++ b/server/server_exchange_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"testing"
 
+	"github.com/valinurovam/garagemq/amqp"
 	"github.com/valinurovam/garagemq/exchange"
 )
 
@@ -11,7 +12,13 @@ func Test_DefaultExchanges(t *testing.T) {
 	defer sc.clean()
 	vhost := sc.server.getVhost("/")
 
-	exchanges := []string{"direct", "fanout", "headers", "topic"}
+	exchanges := []string{"direct", "fanout", "topic"}
+	if vhost.srv.protoVersion == amqp.ProtoRabbit {
+		exchanges = append(exchanges, "header")
+	} else {
+		exchanges = append(exchanges, "match")
+	}
+
 	for _, name := range exchanges {
 		name = "amq." + name
 		if vhost.GetExchange(name) == nil {

--- a/srvstorage/srvstorage.go
+++ b/srvstorage/srvstorage.go
@@ -81,7 +81,7 @@ func (storage *SrvStorage) GetVhosts() map[string]bool {
 // AddBinding add binding into storage
 func (storage *SrvStorage) AddBinding(vhost string, bind *binding.Binding) error {
 	key := fmt.Sprintf("%s.%s.%s", bindingPrefix, vhost, bind.GetName())
-	data, err := bind.Marshal()
+	data, err := bind.Marshal(storage.protoVersion)
 	if err != nil {
 		return err
 	}
@@ -169,7 +169,7 @@ func (storage *SrvStorage) GetVhostBindings(vhost string) []*binding.Binding {
 				return
 			}
 			bind := &binding.Binding{}
-			bind.Unmarshal(value)
+			bind.Unmarshal(value, storage.protoVersion)
 			bindings = append(bindings, bind)
 		},
 	)


### PR DESCRIPTION
Header exchanges are defined by the AMQP standard as a type of exchange
where instead of a routing key, header data is used for routing data to
a client.

This commit adds a very simple, basic support for this kind of
exchanges.