### PR TITLE
server: Signal readiness to systemd on Linux

### DIFF
--- a/server/daemon.go
+++ b/server/daemon.go
@@ -1,0 +1,6 @@
+// +build !linux
+
+package server
+
+func daemonReady() {
+}

--- a/server/daemon_linux.go
+++ b/server/daemon_linux.go
@@ -1,0 +1,10 @@
+package server
+
+import (
+	"github.com/coreos/go-systemd/daemon"
+)
+
+func daemonReady() {
+	// signal readiness, ignore errors
+	daemon.SdNotify(false, daemon.SdNotifyReady)
+}

--- a/server/server.go
+++ b/server/server.go
@@ -173,6 +173,8 @@ func (srv *Server) listen() {
 		"address": address,
 	}).Info("Server started")
 
+	daemonReady()
+
 	for {
 		conn, err := srv.listener.AcceptTCP()
 		if err != nil {


### PR DESCRIPTION
This allows using systemd service files with Type=notify which means the
garagemq service will not be considered as started until it has signaled
that it's ready (after setting up the listening socket).
This causes any other service that has a dependency on garagemq to be
properly delayed until garagemq is up and running.

The daemon.go and daemon_linux.go are split up to avoid pulling
in the go-systemd dependency on non-linux.

Fixes #29