### PR TITLE
replaced github.com/streadway/amqp with github.com/rabbitmq/amqp091-go;

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,10 @@ go 1.19
 require (
 	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf
 	github.com/dgraph-io/badger v1.6.2
+	github.com/rabbitmq/amqp091-go v1.7.0
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.14.0
-	github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94
 	github.com/tidwall/buntdb v1.2.10
 	golang.org/x/crypto v0.4.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -43,7 +43,6 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
@@ -184,6 +183,8 @@ github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qR
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/rabbitmq/amqp091-go v1.7.0 h1:V5CF5qPem5OGSnEo8BoSbsDGwejg6VUJsKEdneaoTUo=
+github.com/rabbitmq/amqp091-go v1.7.0/go.mod h1:wfClAtY0C7bOHxd3GjmF26jEHn+rR/0B3+YV+Vn9/NI=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
@@ -207,8 +208,6 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/spf13/viper v1.14.0 h1:Rg7d3Lo706X9tHsJMUjdiwMpHB7W8WnSVOssIY+JElU=
 github.com/spf13/viper v1.14.0/go.mod h1:WT//axPky3FdvXHzGw33dNdXXXfFQqmEalje+egj8As=
-github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94 h1:0ngsPmuP6XIjiFRNFYlvKwSr5zff2v+uPHaffZ6/M4k=
-github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
@@ -248,12 +247,15 @@ github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.3/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.4/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.5/go.mod h1:5pWMHQbX5EPX2/62yrJeAkowc+lfs/XD7Uxpq3pI6kk=
+go.uber.org/goleak v1.2.0 h1:xqgm/S+aQvhWFTtR0XK3Jvg7z8kGV8P4X14IzwN3Eqk=
+go.uber.org/goleak v1.2.0/go.mod h1:XJYK+MuIchqpmGmUSAzotztawfKvYLUIgg7guXrwVUo=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
@@ -297,6 +299,7 @@ golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.1/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -328,6 +331,7 @@ golang.org/x/net v0.0.0-20201031054903-ff519b6c9102/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20201209123823-ac852fbbde11/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20201224014010-6772e930b67b/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.4.0 h1:Q5QPcMlvfxFTAPV0+07Xz/MpK9NTXu2VDUuy0FeMfaU=
 golang.org/x/net v0.4.0/go.mod h1:MBQ8lrhLObU/6UmLb4fmbmk5OcyYmqtbGd/9yIeKjEE=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -349,6 +353,7 @@ golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -383,7 +388,9 @@ golang.org/x/sys v0.0.0-20201201145000-ef89a241ccb3/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210104204734-6f8348627aad/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210225134936-a50acf3fe073/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -449,6 +456,7 @@ golang.org/x/tools v0.0.0-20201208233053-a543418bbed2/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.0.0-20210105154028-b0ab187a4818/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210108195828-e2f9c7f1fc8e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
+golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/server/channel.go
+++ b/server/channel.go
@@ -8,7 +8,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
 	"github.com/valinurovam/garagemq/amqp"
 	"github.com/valinurovam/garagemq/consumer"
@@ -313,7 +312,7 @@ func (channel *Channel) handleContentBody(bodyFrame *amqp.Frame) *amqp.Error {
 func (channel *Channel) SendMethod(method amqp.Method) {
 	var rawMethod = channel.bufferPool.Get()
 	if err := amqp.WriteMethod(rawMethod, method, channel.server.protoVersion); err != nil {
-		logrus.WithError(err).Error("Error")
+		log.WithError(err).Error("Error")
 	}
 
 	closeAfter := method.ClassIdentifier() == amqp.ClassConnection && method.MethodIdentifier() == amqp.MethodConnectionCloseOk
@@ -375,8 +374,8 @@ func (channel *Channel) addConfirm(meta *amqp.ConfirmMeta) {
 }
 
 func (channel *Channel) sendConfirms() {
-	tick := time.Tick(20 * time.Millisecond)
-	for range tick {
+	tick := time.NewTicker(20 * time.Millisecond)
+	for range tick.C {
 		if channel.status == channelClosed {
 			return
 		}

--- a/server/connection.go
+++ b/server/connection.go
@@ -394,11 +394,9 @@ func (conn *Connection) heartBeater() {
 
 	go func() {
 		for {
-			select {
-			case lastTs, ok = <-conn.lastOutgoingTS:
-				if !ok {
-					return
-				}
+			lastTs, ok = <-conn.lastOutgoingTS
+			if !ok {
+				return
 			}
 		}
 	}()

--- a/server/queueMethods.go
+++ b/server/queueMethods.go
@@ -1,8 +1,6 @@
 package server
 
 import (
-	"fmt"
-
 	"github.com/valinurovam/garagemq/amqp"
 	"github.com/valinurovam/garagemq/binding"
 	"github.com/valinurovam/garagemq/exchange"
@@ -128,7 +126,7 @@ func (channel *Channel) queueBind(method *amqp.QueueBind) *amqp.Error {
 	if ex.GetName() == exDefaultName {
 		return amqp.NewChannelError(
 			amqp.AccessRefused,
-			fmt.Sprintf("operation not permitted on the default exchange"),
+			"operation not permitted on the default exchange",
 			method.ClassIdentifier(),
 			method.MethodIdentifier(),
 		)

--- a/server/server.go
+++ b/server/server.go
@@ -161,6 +161,12 @@ func (srv *Server) getVhost(name string) *VirtualHost {
 func (srv *Server) listen() {
 	address := srv.host + ":" + srv.port
 	tcpAddr, err := net.ResolveTCPAddr("tcp4", address)
+	if err != nil {
+		log.WithError(err).WithFields(log.Fields{
+			"address": address,
+		}).Error("Error resolving tcp address")
+		os.Exit(1)
+	}
 	srv.listener, err = net.ListenTCP("tcp", tcpAddr)
 	if err != nil {
 		log.WithError(err).WithFields(log.Fields{
@@ -329,12 +335,13 @@ func (srv *Server) onSignal(sig os.Signal) {
 }
 
 // Special method for calling in tests without os.Exit(0)
-func (srv *Server) testOnSignal(sig os.Signal) {
-	switch sig {
-	case syscall.SIGTERM, syscall.SIGINT:
-		srv.Stop()
-	}
-}
+// Commented out as it's not currently used
+// func (srv *Server) testOnSignal(sig os.Signal) {
+// 	switch sig {
+// 	case syscall.SIGTERM, syscall.SIGINT:
+// 		srv.Stop()
+// 	}
+// }
 
 func (srv *Server) hookSignals() {
 	c := make(chan os.Signal, 1)

--- a/server/server_channel_test.go
+++ b/server/server_channel_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	amqp2 "github.com/streadway/amqp"
+	amqpclient "github.com/rabbitmq/amqp091-go"
 	"github.com/valinurovam/garagemq/amqp"
 )
 
@@ -84,7 +84,7 @@ func Test_ChannelFlow_Failed_FlowOkSend(t *testing.T) {
 	ch, _ := sc.client.Channel()
 
 	flowChan := make(chan bool)
-	closeChan := make(chan *amqp2.Error, 1)
+	closeChan := make(chan *amqpclient.Error, 1)
 	ch.NotifyFlow(flowChan)
 	ch.NotifyClose(closeChan)
 
@@ -100,7 +100,7 @@ func Test_ChannelFlow_Failed_FlowOkSend(t *testing.T) {
 		fmt.Println(notify)
 	}
 
-	var closeErr *amqp2.Error
+	var closeErr *amqpclient.Error
 
 	select {
 	case closeErr = <-closeChan:

--- a/server/server_confirm_test.go
+++ b/server/server_confirm_test.go
@@ -1,10 +1,11 @@
 package server
 
 import (
+	"context"
 	"testing"
 	"time"
 
-	"github.com/streadway/amqp"
+	amqpclient "github.com/rabbitmq/amqp091-go"
 )
 
 func Test_Confirm_Success(t *testing.T) {
@@ -37,7 +38,7 @@ func Test_ConfirmReceive_Acks_Success(t *testing.T) {
 	queue, _ := ch.QueueDeclare(t.Name(), false, false, false, false, emptyTable)
 
 	for i := 0; i < msgCount; i++ {
-		ch.Publish("", queue.Name, false, false, amqp.Publishing{ContentType: "text/plain", Body: []byte("test")})
+		ch.PublishWithContext(context.Background(), "", queue.Name, false, false, amqpclient.Publishing{ContentType: "text/plain", Body: []byte("test")})
 	}
 
 	tick := time.After(50 * time.Millisecond)
@@ -78,7 +79,7 @@ func Test_ConfirmReceive_Acks_NoRoute_Success(t *testing.T) {
 	ch.QueueDeclare(t.Name(), false, false, false, false, emptyTable)
 
 	for i := 0; i < msgCount; i++ {
-		ch.Publish("", "bad-route", false, false, amqp.Publishing{ContentType: "text/plain", Body: []byte("test")})
+		ch.PublishWithContext(context.Background(), "", "bad-route", false, false, amqpclient.Publishing{ContentType: "text/plain", Body: []byte("test")})
 	}
 
 	tick := time.After(50 * time.Millisecond)
@@ -119,7 +120,7 @@ func Test_ConfirmReceive_Acks_Persistent_Success(t *testing.T) {
 	queue, _ := ch.QueueDeclare(t.Name(), true, false, false, false, emptyTable)
 
 	for i := 0; i < msgCount; i++ {
-		ch.Publish("", queue.Name, false, false, amqp.Publishing{ContentType: "text/plain", Body: []byte("test"), DeliveryMode: amqp.Persistent})
+		ch.PublishWithContext(context.Background(), "", queue.Name, false, false, amqpclient.Publishing{ContentType: "text/plain", Body: []byte("test"), DeliveryMode: amqpclient.Persistent})
 	}
 
 	tick := time.After(50 * time.Millisecond)

--- a/server/server_queue_test.go
+++ b/server/server_queue_test.go
@@ -1,10 +1,11 @@
 package server
 
 import (
+	"context"
 	"testing"
 	"time"
 
-	"github.com/streadway/amqp"
+	amqpclient "github.com/rabbitmq/amqp091-go"
 )
 
 func Test_QueueDeclare_Success(t *testing.T) {
@@ -125,7 +126,7 @@ func Test_QueueDeclarePassive_Failed_NotExists(t *testing.T) {
 
 	ch.QueueDeclare(t.Name(), false, false, false, false, emptyTable)
 
-	if _, err := ch.QueueDeclarePassive(t.Name() + "new", false, false, false, false, emptyTable); err == nil {
+	if _, err := ch.QueueDeclarePassive(t.Name()+"new", false, false, false, false, emptyTable); err == nil {
 		t.Error("Expected: queue not found error")
 	}
 }
@@ -343,7 +344,7 @@ func Test_QueuePurge_Success(t *testing.T) {
 
 	msgCount := 10
 	for i := 0; i < msgCount; i++ {
-		ch.Publish("", queue.Name, false, false, amqp.Publishing{ContentType: "text/plain", Body: []byte("test")})
+		ch.PublishWithContext(context.Background(), "", queue.Name, false, false, amqpclient.Publishing{ContentType: "text/plain", Body: []byte("test")})
 	}
 
 	time.Sleep(5 * time.Millisecond)
@@ -401,7 +402,7 @@ func Test_QueueDelete_Success(t *testing.T) {
 
 	msgCount := 10
 	for i := 0; i < msgCount; i++ {
-		ch.Publish("", queue.Name, false, false, amqp.Publishing{ContentType: "text/plain", Body: []byte("test")})
+		ch.PublishWithContext(context.Background(), "", queue.Name, false, false, amqpclient.Publishing{ContentType: "text/plain", Body: []byte("test")})
 	}
 
 	time.Sleep(5 * time.Millisecond)
@@ -427,7 +428,7 @@ func Test_QueueDeleteDurable_Success(t *testing.T) {
 
 	msgCount := 10
 	for i := 0; i < msgCount; i++ {
-		ch.Publish("", queue.Name, false, false, amqp.Publishing{ContentType: "text/plain", Body: []byte("test")})
+		ch.PublishWithContext(context.Background(), "", queue.Name, false, false, amqpclient.Publishing{ContentType: "text/plain", Body: []byte("test")})
 	}
 
 	time.Sleep(5 * time.Millisecond)
@@ -469,7 +470,7 @@ func Test_QueueDelete_Failed_NotEmpty(t *testing.T) {
 
 	msgCount := 10
 	for i := 0; i < msgCount; i++ {
-		ch.Publish("", queue.Name, false, false, amqp.Publishing{ContentType: "text/plain", Body: []byte("test")})
+		ch.PublishWithContext(context.Background(), "", queue.Name, false, false, amqpclient.Publishing{ContentType: "text/plain", Body: []byte("test")})
 	}
 
 	time.Sleep(5 * time.Millisecond)


### PR DESCRIPTION
GarageMQ uses `github.com/streadway/amqp` AMQP client for unit tests, but that library is no longer maintained and GarageMQ should switch to using the standard `github.com/rabbitmq/amqp091-go` AMQP client provided and maintained by RabbitMQ.