### PR TITLE
Adding support for memory-only BuntDB

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -6,6 +6,13 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+const (
+	DbEngineTypeBadger string = "badger"
+	DbEngineTypeBuntDb string = "buntdb"
+
+	DbPathMemory string = ":memory:"
+)
+
 // Config represents server changeable se
 type Config struct {
 	Proto      string

--- a/server/server_basic_test.go
+++ b/server/server_basic_test.go
@@ -9,6 +9,7 @@ import (
 
 	amqpclient "github.com/rabbitmq/amqp091-go"
 	"github.com/valinurovam/garagemq/amqp"
+	"github.com/valinurovam/garagemq/config"
 )
 
 func Test_BasicQos_Channel_Success(t *testing.T) {
@@ -52,6 +53,19 @@ func Test_BasicQos_Global_Success(t *testing.T) {
 }
 
 func Test_BasicQos_Check_Global_Success(t *testing.T) {
+	test_BasicQos_Check_Global_Success(t, getDefaultTestConfig())
+}
+
+func Test_BasicQos_InMemory_Check_Global_Success(t *testing.T) {
+	cfg := getDefaultTestConfig()
+	// Configure in-memory db
+	cfg.srvConfig.Db.DefaultPath = config.DbPathMemory
+	cfg.srvConfig.Db.Engine = config.DbEngineTypeBuntDb
+
+	test_BasicQos_Check_Global_Success(t, cfg)
+}
+
+func test_BasicQos_Check_Global_Success(t *testing.T, cfg TestConfig) {
 	sc, _ := getNewSC(getDefaultTestConfig())
 	defer sc.clean()
 	ch, _ := sc.client.Channel()

--- a/storage/storage_bunt.go
+++ b/storage/storage_bunt.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/tidwall/buntdb"
+	"github.com/valinurovam/garagemq/config"
 	"github.com/valinurovam/garagemq/interfaces"
 )
 
@@ -17,7 +18,10 @@ type BuntDB struct {
 func NewBuntDB(storagePath string) *BuntDB {
 	storage := &BuntDB{}
 
-	storagePath = fmt.Sprintf("%s/%s", storagePath, "db")
+	if storagePath != config.DbPathMemory {
+		storagePath = fmt.Sprintf("%s/%s", storagePath, "db")
+	}
+
 	var db, err = buntdb.Open(storagePath)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
I need the option to run embedded GarageMQ without persisting in the file system (for my API in simulation mode). BuntDB natively supports memory-only storage, I just modified some code + added unit tests to allow that.